### PR TITLE
Sgrouard/sanity checks

### DIFF
--- a/notebooks/deconvo_sanity_checks.py
+++ b/notebooks/deconvo_sanity_checks.py
@@ -1,0 +1,252 @@
+"""Perform the sanity checks once deconvolution type 1 is performed."""
+# flake8: noqa
+# %%
+import scanpy as sc
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+import random
+import mygene
+from sklearn.model_selection import train_test_split
+from scipy.stats import pearsonr
+
+from sanity_checks_utils import (
+    GROUPS,
+    map_hgnc_to_ensg,
+    perform_nnls,
+    compute_correlations,
+)
+
+# %%
+# import data
+adata = sc.read("/home/owkin/data/cross-tissue/omics/raw/local.h5ad")
+signature_laughney = pd.read_csv(
+    "/home/owkin/data/laughney_signature.csv", index_col=0
+).drop(["Endothelial", "Malignant", "Stroma", "Epithelial"], axis=1)
+# primary cell type categories
+groups = GROUPS["primary_groups"]
+
+# %%
+# create cell types
+group_correspondence = {}
+for k, v in groups.items():
+    for cell_type in v:
+        group_correspondence[cell_type] = k
+adata.obs["cell_types_grouped"] = [
+    group_correspondence[cell_type] for cell_type in adata.obs.Manually_curated_celltype
+]
+
+# remove some cell types: you need more than 15GB memory to run that
+index_to_keep = adata.obs.loc[adata.obs["cell_types_grouped"] != "To remove"].index
+adata = adata[index_to_keep]
+
+
+# %%
+# build signature on train set and apply deconvo on the test set
+cell_types_train, cell_types_test = train_test_split(
+    adata.obs_names,
+    test_size=0.5,
+    stratify=adata.obs.cell_types_grouped,
+    random_state=42,
+)
+adata = adata[cell_types_test, :]
+# signature = ... (with train set)
+
+
+# %%
+# map the HGNC notation to ENSG if the signature matrix uses HGNC notation
+mg = mygene.MyGeneInfo()
+genes = mg.querymany(
+    signature_laughney.index,
+    scopes="symbol",
+    fields=["ensembl"],
+    species="human",
+    verbose=False,
+    as_dataframe=True,
+)
+ensg_names = map_hgnc_to_ensg(genes, adata)
+signature = signature_laughney.copy()
+signature.index = ensg_names
+
+# intersection between all genes and marker genes
+intersection = list(set(adata.var_names).intersection(signature.index))
+signature = signature.loc[intersection]
+
+
+# %%
+# Sanity check 1: Pseudobulks for each cell type → the closest the fraction is to 1 the best
+
+# The following is the equivalent of averaged_data = adata.groupby("cell_types_grouped").X.mean(axis = 0)
+# but there is no "groupby" function for an anndata sparse matrix
+grouped = adata.obs.groupby("cell_types_grouped")
+averaged_data, group = [], []
+for group_key, group_indices in grouped.groups.items():
+    averaged_data.append(adata[group_indices].X.mean(axis=0).tolist()[0])
+    group.append(group_key)
+
+averaged_data = pd.DataFrame(averaged_data, index=group, columns=adata.var_names)
+
+# intersection between all genes and marker genes
+averaged_data = averaged_data[intersection]
+
+# 5 different deconvolutions with n_marker_genes observations each
+deconv_results = perform_nnls(signature, averaged_data)
+
+# melt the matrix for seaborn
+deconv_results_melted = pd.melt(
+    deconv_results.T.reset_index(),
+    id_vars="index",
+    var_name="Cell type",
+    value_name="Fraction",
+).rename({"index": "Cell type predicted"}, axis=1)
+
+# if one deconv method only
+sns.set_style("whitegrid")
+sns.stripplot(
+    data=deconv_results_melted, x="Cell type", y="Fraction", hue="Cell type predicted"
+)
+plt.show()
+
+# if comparison of several deconv methods
+deconv_results_melted_methods = deconv_results_melted.loc[
+    deconv_results_melted["Cell type predicted"] == deconv_results_melted["Cell type"]
+].copy()
+deconv_results_melted_methods["Method"] = "nnls"  # add all the deconv methods
+sns.set_style("whitegrid")
+sns.stripplot(
+    data=deconv_results_melted_methods, x="Cell type", y="Fraction", hue="Method"
+)
+plt.show()
+
+
+# %%
+# Sanity check 2: Pseudobulks from predefined fractions → correlation between the
+# fractions of selected cells (“ground truth”)  and the estimated fractions
+
+n_sample = 100
+random.seed(42)
+averaged_data = []
+ground_truth_fractions = []
+for i in range(n_sample):
+    cell_sample = random.sample(list(adata.obs_names), 1000)
+    adata_sample = adata[cell_sample, :]
+    ground_truth_frac = adata_sample.obs.cell_types_grouped.value_counts() / 1000
+    ground_truth_fractions.append(ground_truth_frac)
+    averaged_data.append(adata_sample.X.mean(axis=0).tolist()[0])
+
+averaged_data = pd.DataFrame(
+    averaged_data, index=range(n_sample), columns=adata.var_names
+)
+ground_truth_fractions = pd.DataFrame(ground_truth_fractions, index=range(n_sample))
+ground_truth_fractions = ground_truth_fractions.fillna(
+    0
+)  # the Nan are cells not sampled
+
+# intersection between all genes and marker genes
+averaged_data = averaged_data[intersection]
+
+# 100 different deconvolutions with n_marker_genes observations each
+deconv_results = perform_nnls(signature, averaged_data)
+
+# compute correlations
+correlations = compute_correlations(deconv_results, ground_truth_fractions)
+
+# boxplot of the correlations for the method
+sns.set_style("whitegrid")
+boxplot = sns.boxplot(correlations, y="correlations", x="Method")
+medians = correlations.groupby(["Method"])["correlations"].median().round(4)
+vertical_offset = (
+    correlations["correlations"].median() * 0.0005
+)  # for non-overlapping display
+for xtick in boxplot.get_xticks():  # show the median value
+    boxplot.text(
+        xtick,
+        medians[xtick] + vertical_offset,
+        medians[xtick],
+        horizontalalignment="center",
+        size="x-small",
+        color="w",
+        weight="semibold",
+    )
+plt.show()
+
+
+# %%
+# Sanity check 3: Pseudobulks from random selection of cells (e.g. Dirichlet
+# distribution) → correlation between the fractions of selected cells (“ground truth”)
+# and the estimated fractions
+
+n_sample = 100
+
+# compute dirichlet posteriors to sample cells
+# nb: dirichlet is conjugate to the multinomial distribution, thus giving an easy
+# posterior calculation
+np.random.seed(42)
+prior_alphas = np.ones(
+    len(signature.columns)
+)  # non-informative prior: if prior belief, should be incorporated here
+likelihood_alphas = adata.obs.cell_types_grouped.value_counts() / len(
+    adata.obs
+)  # multinomial likelihood (TO CHECK: maths behind average or sum for the likelihood)
+alpha_posterior = (
+    prior_alphas + likelihood_alphas
+)  # (TO CHECK: maths behind this simple addition)
+posterior_dirichlet = np.random.dirichlet(alpha_posterior, n_sample)
+posterior_dirichlet = np.round(posterior_dirichlet * 500)
+posterior_dirichlet = posterior_dirichlet.astype(np.int64)  # number of cells to sample
+
+ground_truth_fractions = posterior_dirichlet / posterior_dirichlet.sum(
+    axis=1, keepdims=True
+)
+ground_truth_fractions = pd.DataFrame(
+    ground_truth_fractions, columns=alpha_posterior.index
+)
+
+random.seed(42)
+averaged_data = []
+for i in range(n_sample):
+    sample_data = []
+    for j, cell_type in enumerate(likelihood_alphas.index):
+        # is there a way to optimise by not doing this loop?
+        cell_sample = random.sample(
+            list(adata.obs.loc[adata.obs.cell_types_grouped == cell_type].index),
+            posterior_dirichlet[i][j],
+        )
+        adata_sample = adata[cell_sample, :]
+        sample_data.append(adata_sample.X.mean(axis=0).tolist()[0])
+    averaged_data.append(np.array(sample_data).mean(axis=0))
+
+averaged_data = pd.DataFrame(
+    averaged_data, index=range(n_sample), columns=adata.var_names
+)
+
+# intersection between all genes and marker genes
+averaged_data = averaged_data[intersection]
+
+# 100 different deconvolutions with n_marker_genes observations each
+deconv_results = perform_nnls(signature, averaged_data)
+
+# compute correlations
+correlations = compute_correlations(deconv_results, ground_truth_fractions)
+
+# boxplot of the correlations for the method
+sns.set_style("whitegrid")
+boxplot = sns.boxplot(correlations, y="correlations", x="Method")
+medians = correlations.groupby(["Method"])["correlations"].median().round(4)
+vertical_offset = (
+    correlations["correlations"].median() * 0.0005
+)  # for non-overlapping display
+for xtick in boxplot.get_xticks():  # show the median value
+    boxplot.text(
+        xtick,
+        medians[xtick] + vertical_offset,
+        medians[xtick],
+        horizontalalignment="center",
+        size="x-small",
+        color="w",
+        weight="semibold",
+    )
+plt.show()
+
+# %%

--- a/notebooks/deconvo_sanity_checks.py
+++ b/notebooks/deconvo_sanity_checks.py
@@ -26,8 +26,8 @@ signature_laughney = pd.read_csv(
     "/home/owkin/data/laughney_signature.csv", index_col=0
 ).drop(["Endothelial", "Malignant", "Stroma", "Epithelial"], axis=1)
 signature_almudena = read_almudena_signature(
-    "/home/owkin/project/Almudena/Output/Crosstiss_Immune/CTI.txt"
-)
+    "/home/owkin/project/Almudena/Output/Crosstiss_Immune_norm/CTI.txt"
+)  # it is the normalised one (using adata.X and not adata.raw.X, to match this code)
 # primary cell type categories
 groups = GROUPS["primary_groups"]
 

--- a/notebooks/sanity_checks_utils.py
+++ b/notebooks/sanity_checks_utils.py
@@ -105,6 +105,31 @@ GROUPS = {
 }
 
 
+def read_almudena_signature(path):
+    """Read Almudena's signature matrix. Requires this function because it's a txt file
+    delimited with various delimiters.
+    """
+    signature_almudena = []
+    with open(path, "r") as file:
+        for line in file:
+            temp = []
+            for elem in line.split("\t"):
+                try:
+                    temp.append(float(elem))
+                except:
+                    elem = elem.replace('"', "")
+                    elem = elem.replace("\n", "")
+                    temp.append(elem)
+            signature_almudena.append(temp)
+
+    signature_almudena = pd.DataFrame(signature_almudena).set_index(0)
+    signature_almudena.columns = signature_almudena.iloc[0]
+    signature_almudena = signature_almudena.drop("")
+    signature_almudena.index.name = "Genes"
+    signature_almudena.columns.name = None
+    return signature_almudena
+
+
 def map_hgnc_to_one_ensg(gene_names, adata):
     """
     If a HGNC symbol map to multiple ENSG symbols, choose the one that is in the

--- a/notebooks/sanity_checks_utils.py
+++ b/notebooks/sanity_checks_utils.py
@@ -1,0 +1,174 @@
+"""Different python functions useful for sanity checks in deconvolution."""
+
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+GROUPS = {
+    "primary_groups": {
+        "B": [
+            "ABCs",
+            "GC_B (I)",
+            "GC_B (II)",
+            "Memory B cells",
+            "Naive B cells",
+            "Plasma cells",
+            "Plasmablasts",
+            "Pre-B",
+            "Pro-B",
+        ],
+        "MonoMacro": [
+            "Alveolar macrophages",
+            "Classical monocytes",
+            "Erythrophagocytic macrophages",
+            "Intermediate macrophages",
+            "Nonclassical monocytes",
+        ],
+        "TNK": [
+            "Cycling T&NK",
+            "MAIT",
+            "NK_CD16+",
+            "NK_CD56bright_CD16-",
+            "T_CD4/CD8",
+            "Teffector/EM_CD4",
+            "Tem/emra_CD8",
+            "Tfh",
+            "Tgd_CRTAM+",
+            "Tnaive/CM_CD4",
+            "Tnaive/CM_CD4_activated",
+            "Tnaive/CM_CD8",
+            "Tregs",
+            "Trm/em_CD8",
+            "Trm_Tgd",
+            "Trm_Th1/Th17",
+            "Trm_gut_CD8",
+            "ILC3",
+        ],
+        "DC": ["DC1", "DC2", "migDC", "pDC"],
+        "Mast": ["Mast cells"],
+        "To remove": [
+            "Erythroid",
+            "Megakaryocytes",
+            "Progenitor",
+            "Cycling",
+            "T/B doublets",
+            "MNP/B doublets",
+            "MNP/T doublets",
+            "Intestinal macrophages",
+        ],
+    },
+    "precise_groups": {
+        "B": [
+            "ABCs",
+            "GC_B (I)",
+            "GC_B (II)",
+            "MNP/B doublets",
+            "Memory B cells",
+            "Naive B cells",
+            "Pre-B",
+            "Pro-B",
+        ],
+        "Plasma": ["Plasma cells", "Plasmablasts"],
+        "Mono": ["Classical monocytes", "Nonclassical monocytes"],
+        "Macro": [
+            "Alveolar macrophages",
+            "Erythrophagocytic macrophages",
+            "Intermediate macrophages",
+            "Intestinal macrophages",
+        ],
+        "T": [
+            "MAIT",
+            "MNP/T doublets",
+            "T_CD4/CD8",
+            "Teffector/EM_CD4",
+            "Tem/emra_CD8",
+            "Tfh",
+            "Tgd_CRTAM+",
+            "Tnaive/CM_CD4",
+            "Tnaive/CM_CD4_activated",
+            "Tnaive/CM_CD8",
+            "Tregs",
+            "Trm/em_CD8",
+            "Trm_Tgd",
+            "Trm_Th1/Th17",
+            "Trm_gut_CD8",
+        ],
+        "NK": ["NK_CD16+", "NK_CD56bright_CD16-"],
+        "ICL3": ["ILC3"],
+        "DC": ["DC1", "DC2", "migDC", "pDC"],
+        "Mast": ["Mast cells"],
+        "Red_blood": ["Erythroid"],
+        "Bone_marrow": ["Megakaryocytes"],
+        "Non-differentiated": ["Progenitor"],
+        "To remove": ["Cycling", "T/B doublets", "Cycling T&NK"],
+    },
+}
+
+
+def map_hgnc_to_one_ensg(gene_names, adata):
+    """
+    If a HGNC symbol map to multiple ENSG symbols, choose the one that is in the
+    single cell dataset.
+    If the HGNC symbol maps to multiple ENSG symbols even inside the scRNAseq dataset,
+    then the last one is chosen (no rationale).
+    """
+    chosen_gene = None
+    for gene_name in gene_names:
+        if gene_name in adata.var_names:
+            chosen_gene = gene_name
+    return chosen_gene
+
+
+def map_hgnc_to_ensg(genes, adata):
+    """
+    Map the HGNC symbols from the signature matrix to the corresponding ENSG symbols
+    of the scRNAseq dataset.
+    """
+    ensg_names = []
+    for gene in genes.index:
+        if len(genes.loc[gene].shape) > 1:
+            # then one hgnc has multiple ensg lines in the dataframe
+            gene_names = genes.loc[gene, "ensembl.gene"]
+            gene_name = map_hgnc_to_one_ensg(gene_names, adata)
+            if gene_name not in ensg_names:  # for duplicates
+                ensg_names.append(gene_name)
+        elif genes.loc[gene, "notfound"] is True:
+            # then the hgnc gene cannot be mapped to ensg
+            ensg_names.append("notfound")
+        elif genes.loc[gene, "ensembl.gene"] != genes.loc[gene, "ensembl.gene"]:
+            # then one hgnc gene has multiple ensg mappings in one line of the dataframe
+            ensembl = genes.loc[gene, "ensembl"]
+            gene_names = [ensembl[i]["gene"] for i in range(len(ensembl))]
+            gene_name = map_hgnc_to_one_ensg(gene_names, adata)
+            ensg_names.append(gene_name)
+        else:
+            # then one hgnc corresponds to one ensg
+            ensg_names.append(genes.loc[gene, "ensembl.gene"])
+    return ensg_names
+
+
+def perform_nnls(signature, averaged_data):
+    """Perform deconvolution using the nnls method.
+    It will be performed as many times as there are samples in averaged_data.
+    """
+    deconv = LinearRegression(positive=True).fit(signature, averaged_data.T)
+    deconv_results = pd.DataFrame(
+        deconv.coef_, index=averaged_data.index, columns=signature.columns
+    )
+    deconv_results = deconv_results.div(
+        deconv_results.sum(axis=1), axis=0
+    )  # to sum up to 1
+    return deconv_results
+
+
+def compute_correlations(deconv_results, ground_truth_fractions):
+    """Compute n_sample pairwise correlations between the deconvolution results and the
+    ground truth fractions.
+    """
+    correlations = pd.concat(
+        [deconv_results.T, ground_truth_fractions.T], axis=1, keys=["df1", "df2"]
+    )
+    correlations = np.diag(correlations.corr().loc["df2", "df1"])
+    correlations = pd.DataFrame({"correlations": correlations})
+    correlations["Method"] = "nnls"  # add all the deconv methods
+    return correlations


### PR DESCRIPTION
The sanity checks converted from python to R. 
They use the data and signature matrix that is normalised (adata.X and not adata.raw.X) right now.
The first two sanity checks seem to work well. The last one not so much. It may be due to twi things: 
1. The cell numbers to sample from each cell type coming from the dirichlet distribution are sometimes hard to recover with the nnls somehow. This is not likely, as the test is not too different from the sanity check #2, and this latter works well.
2. The computation of the pseudo-bulk with the matching between the number of cells that are supposed to be sampled and the effective number of cells that end up being sampled has an issue in the code. If so, that could also explain why the correlation between the two is low.